### PR TITLE
Str parse2

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,6 @@ impl<'de> Deserializer<'de> {
             }
         }
 
-        dbg!(len);
-        dbg!(src_i);
         let mut dst_i: usize = 0;
         let dst: &mut [u8] = &mut self.strings;
 
@@ -389,7 +387,6 @@ impl<'de> Deserializer<'de> {
 
                 dst_i += quote_dist as usize;
                 unsafe {
-                    dbg!(idx + len..idx + len + dst_i as usize);
                     self.input
                         .get_unchecked_mut(idx + len..idx + len + dst_i)
                         .clone_from_slice(&self.strings.get_unchecked(..dst_i));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,19 +157,16 @@ impl<'de> Deserializer<'de> {
             }
         };
 
-        let (counts, str_len) = Deserializer::validate(input, &structural_indexes)?;
+        let counts = Deserializer::validate(input, &structural_indexes)?;
 
-        let mut v = Vec::with_capacity(str_len + SIMDJSON_PADDING);
-        unsafe {
-            v.set_len(str_len + SIMDJSON_PADDING);
-        };
+        let strings = Vec::with_capacity(len + SIMDJSON_PADDING);
 
         Ok(Deserializer {
             counts,
             structural_indexes,
             input,
             idx: 0,
-            strings: v,
+            strings,
             str_offset: 0,
             iidx: 0,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,53 +206,6 @@ impl<'de> Deserializer<'de> {
         unsafe { *self.counts.get_unchecked(self.idx) }
     }
 
-    // We parse a string that's likely to be less then 32 characters and without any
-    // fancy in it like object keys
-    #[cfg_attr(not(feature = "no-inline"), inline(always))]
-    fn parse_short_str_(&mut self) -> Result<&'de str> {
-        let mut padding = [0u8; 32];
-        let idx = self.iidx + 1;
-        let src: &[u8] = unsafe { &self.input.get_unchecked(idx..) };
-
-        //short strings are very common for IDs
-        let v: __m256i = if src.len() >= 32 {
-            // This is safe since we ensure src is at least 32 wide
-            #[allow(clippy::cast_ptr_alignment)]
-            unsafe {
-                _mm256_loadu_si256(src.get_unchecked(..32).as_ptr() as *const __m256i)
-            }
-        } else {
-            unsafe {
-                padding
-                    .get_unchecked_mut(..src.len())
-                    .clone_from_slice(&src);
-                // This is safe since we ensure src is at least 32 wide
-                #[allow(clippy::cast_ptr_alignment)]
-                _mm256_loadu_si256(padding.get_unchecked(..32).as_ptr() as *const __m256i)
-            }
-        };
-        let bs_bits: u32 = unsafe {
-            static_cast_u32!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(
-                v,
-                _mm256_set1_epi8(b'\\' as i8)
-            )))
-        };
-        let quote_mask = unsafe { _mm256_cmpeq_epi8(v, _mm256_set1_epi8(b'"' as i8)) };
-        let quote_bits = unsafe { static_cast_u32!(_mm256_movemask_epi8(quote_mask)) };
-        if (bs_bits.wrapping_sub(1) & quote_bits) != 0 {
-            let quote_dist: u32 = trailingzeroes(u64::from(quote_bits)) as u32;
-            let v = unsafe {
-                self.input.get_unchecked(idx..idx + quote_dist as usize) as *const [u8]
-                    as *const str
-            };
-
-            unsafe {
-                return Ok(&*v);
-            }
-        }
-        self.parse_str_()
-    }
-
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_str_(&mut self) -> Result<&'de str> {
         // Add 1 to skip the initial "
@@ -264,11 +217,6 @@ impl<'de> Deserializer<'de> {
         // This is safe since we check sub's lenght in the range access above and only
         // create sub sliced form sub to `sub.len()`.
 
-        // if we don't need relocation we can write directly to the input
-        // saving us to copy data to the string storage first and then
-        // back tot he input.
-        // We can't always do that as if we're less then 32 characters
-        // behind we'll overwrite important parts of the input.
         let src: &[u8] = unsafe { &self.input.get_unchecked(idx..) };
         let mut src_i: usize = 0;
         let mut len = src_i;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! most of the design closely with a few exceptions to make it better
 //! fit into the rust ecosystem.
 //!
-//! Note: by default rustc will compile for compatibility, not 
+//! Note: by default rustc will compile for compatibility, not
 //! performance, to take advantage of the simd part of simd json. You
 //! have to use a native cpu target on a avx2 capable host system. An
 //! example how to do this can be found in the `.cargo` directory on
@@ -245,7 +245,6 @@ impl<'de> Deserializer<'de> {
                 self.input.get_unchecked(idx..idx + quote_dist as usize) as *const [u8]
                     as *const str
             };
-            self.str_offset = idx + quote_dist as usize;
 
             unsafe {
                 return Ok(&*v);
@@ -256,13 +255,11 @@ impl<'de> Deserializer<'de> {
 
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_str_(&mut self) -> Result<&'de str> {
-        use std::slice::from_raw_parts_mut;
         // Add 1 to skip the initial "
         let idx = self.iidx + 1;
         let mut padding = [0u8; 32];
         //let mut read: usize = 0;
 
-        let needs_relocation = idx - self.str_offset <= 32;
         // we include the terminal '"' so we know where to end
         // This is safe since we check sub's lenght in the range access above and only
         // create sub sliced form sub to `sub.len()`.
@@ -272,17 +269,78 @@ impl<'de> Deserializer<'de> {
         // back tot he input.
         // We can't always do that as if we're less then 32 characters
         // behind we'll overwrite important parts of the input.
-        let dst: &mut [u8] = if needs_relocation {
-            &mut self.strings
-        } else {
-            let ptr = self.input.as_mut_ptr();
-            unsafe {
-                from_raw_parts_mut(ptr.add(self.str_offset), self.input.len() - self.str_offset)
-            }
-        };
         let src: &[u8] = unsafe { &self.input.get_unchecked(idx..) };
         let mut src_i: usize = 0;
+        let mut len = src_i;
+        loop {
+            let v: __m256i = if src.len() >= src_i + 32 {
+                // This is safe since we ensure src is at least 32 wide
+                #[allow(clippy::cast_ptr_alignment)]
+                unsafe {
+                    _mm256_loadu_si256(src.as_ptr().add(src_i) as *const __m256i)
+                }
+            } else {
+                unsafe {
+                    padding
+                        .get_unchecked_mut(..src.len() - src_i)
+                        .clone_from_slice(src.get_unchecked(src_i..));
+                    // This is safe since we ensure src is at least 32 wide
+                    #[allow(clippy::cast_ptr_alignment)]
+                    _mm256_loadu_si256(padding.as_ptr() as *const __m256i)
+                }
+            };
+
+            // store to dest unconditionally - we can overwrite the bits we don't like
+            // later
+            let bs_bits: u32 = unsafe {
+                static_cast_u32!(_mm256_movemask_epi8(_mm256_cmpeq_epi8(
+                    v,
+                    _mm256_set1_epi8(b'\\' as i8)
+                )))
+            };
+            let quote_mask = unsafe { _mm256_cmpeq_epi8(v, _mm256_set1_epi8(b'"' as i8)) };
+            let quote_bits = unsafe { static_cast_u32!(_mm256_movemask_epi8(quote_mask)) };
+            if (bs_bits.wrapping_sub(1) & quote_bits) != 0 {
+                // we encountered quotes first. Move dst to point to quotes and exit
+                // find out where the quote is...
+                let quote_dist: u32 = trailingzeroes(u64::from(quote_bits)) as u32;
+
+                ///////////////////////
+                // Above, check for overflow in case someone has a crazy string (>=4GB?)
+                // But only add the overflow check when the document itself exceeds 4GB
+                // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
+                ////////////////////////
+
+                // we advance the point, accounting for the fact that we have a NULl termination
+
+                len += quote_dist as usize;
+                unsafe {
+                    let v = self.input.get_unchecked(idx..idx + len) as *const [u8] as *const str;
+                    return Ok(&*v);
+                }
+
+                // we compare the pointers since we care if they are 'at the same spot'
+                // not if they are the same value
+            }
+            if (quote_bits.wrapping_sub(1) & bs_bits) != 0 {
+                // Move to the 'bad' character
+                let bs_dist: u32 = trailingzeroes(u64::from(bs_bits));
+                len += bs_dist as usize;
+                src_i += bs_dist as usize;
+                break;
+            } else {
+                // they are the same. Since they can't co-occur, it means we encountered
+                // neither.
+                src_i += 32;
+                len += 32;
+            }
+        }
+
+        dbg!(len);
+        dbg!(src_i);
         let mut dst_i: usize = 0;
+        let dst: &mut [u8] = &mut self.strings;
+
         loop {
             let v: __m256i = if src.len() >= src_i + 32 {
                 // This is safe since we ensure src is at least 32 wide
@@ -331,15 +389,12 @@ impl<'de> Deserializer<'de> {
 
                 dst_i += quote_dist as usize;
                 unsafe {
-                    if needs_relocation {
-                        self.input
-                            .get_unchecked_mut(self.str_offset..self.str_offset + dst_i as usize)
-                            .clone_from_slice(&self.strings.get_unchecked(..dst_i));
-                    }
-                    let v = self
-                        .input
-                        .get_unchecked(self.str_offset..self.str_offset + dst_i as usize)
-                        as *const [u8] as *const str;
+                    dbg!(idx + len..idx + len + dst_i as usize);
+                    self.input
+                        .get_unchecked_mut(idx + len..idx + len + dst_i)
+                        .clone_from_slice(&self.strings.get_unchecked(..dst_i));
+                    let v = self.input.get_unchecked(idx..idx + len + dst_i) as *const [u8]
+                        as *const str;
                     self.str_offset += dst_i as usize;
                     return Ok(&*v);
                 }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -75,7 +75,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
         if let Some(next) = self.structural_indexes.get(self.idx + 1) {
             if *next as usize - self.iidx < 32 {
-                return visitor.visit_borrowed_str(stry!(self.parse_short_str_()));
+                return visitor.visit_borrowed_str(stry!(self.parse_str_()));
             }
         }
         visitor.visit_borrowed_str(stry!(self.parse_str_()))
@@ -91,7 +91,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
         if let Some(next) = self.structural_indexes.get(self.idx + 1) {
             if *next as usize - self.iidx < 32 {
-                return visitor.visit_str(stry!(self.parse_short_str_()));
+                return visitor.visit_str(stry!(self.parse_str_()));
             }
         }
         visitor.visit_str(stry!(self.parse_str_()))

--- a/src/value/borrowed.rs
+++ b/src/value/borrowed.rs
@@ -181,12 +181,7 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            b'"' => {
-                if self.de.count_elements() < 32 {
-                    return self.de.parse_short_str_().map(Value::from);
-                }
-                self.de.parse_str_().map(Value::from)
-            }
+            b'"' => self.de.parse_str_().map(Value::from),
             b'-' => self.de.parse_number_root(true).map(Value::from),
             b'0'..=b'9' => self.de.parse_number_root(false).map(Value::from),
             b'n' => Ok(Value::Null),
@@ -201,14 +196,7 @@ impl<'de> BorrowDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_value(&mut self) -> Result<Value<'de>> {
         match self.de.next_() {
-            b'"' => {
-                // We can only have entered this by being in an object so we know there is
-                // something following as we made sure during checking for sizes.;
-                if self.de.count_elements() < 32 {
-                    return self.de.parse_short_str_().map(Value::from);
-                }
-                self.de.parse_str_().map(Value::from)
-            }
+            b'"' => self.de.parse_str_().map(Value::from),
             b'-' => self.de.parse_number_(true).map(Value::from),
             b'0'..=b'9' => self.de.parse_number_(false).map(Value::from),
             b'n' => Ok(Value::Null),
@@ -253,7 +241,7 @@ impl<'de> BorrowDeserializer<'de> {
 
         for _ in 0..es {
             self.de.skip();
-            let key = stry!(self.de.parse_short_str_());
+            let key = stry!(self.de.parse_str_());
             // We have to call parse short str twice since parse_short_str
             // does not move the cursor forward
             self.de.skip();

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -196,7 +196,7 @@ impl<'de> OwnedDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_value(&mut self) -> Result<Value> {
         match self.de.next_() {
-            b'"' => self.parse_str_().map(Value::from),
+            b'"' => self.de.parse_str_().map(Value::from),
             b'n' => Ok(Value::Null),
             b't' => Ok(Value::Bool(true)),
             b'f' => Ok(Value::Bool(false)),

--- a/src/value/owned.rs
+++ b/src/value/owned.rs
@@ -181,14 +181,7 @@ impl<'de> OwnedDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     pub fn parse(&mut self) -> Result<Value> {
         match self.de.next_() {
-            b'"' => {
-                let next =
-                    unsafe { *self.de.structural_indexes.get_unchecked(self.de.idx + 1) as usize };
-                if next - self.de.iidx < 32 {
-                    return self.de.parse_short_str_().map(Value::from);
-                }
-                self.de.parse_str_().map(Value::from)
-            }
+            b'"' => self.de.parse_str_().map(Value::from),
             b'n' => Ok(Value::Null),
             b't' => Ok(Value::Bool(true)),
             b'f' => Ok(Value::Bool(false)),
@@ -203,14 +196,7 @@ impl<'de> OwnedDeserializer<'de> {
     #[cfg_attr(not(feature = "no-inline"), inline(always))]
     fn parse_value(&mut self) -> Result<Value> {
         match self.de.next_() {
-            b'"' => {
-                let next =
-                    unsafe { *self.de.structural_indexes.get_unchecked(self.de.idx + 1) as usize };
-                if next - self.de.iidx < 32 {
-                    return self.de.parse_short_str_().map(Value::from);
-                }
-                self.de.parse_str_().map(Value::from)
-            }
+            b'"' => self.parse_str_().map(Value::from),
             b'n' => Ok(Value::Null),
             b't' => Ok(Value::Bool(true)),
             b'f' => Ok(Value::Bool(false)),
@@ -255,7 +241,7 @@ impl<'de> OwnedDeserializer<'de> {
 
         for _ in 0..es {
             self.de.skip();
-            let key = stry!(self.de.parse_short_str_());
+            let key = stry!(self.de.parse_str_());
             // We have to call parse short str twice since parse_short_str
             // does not move the cursor forward
             self.de.skip();


### PR DESCRIPTION
This improvs string parsing. We can get around quite a bit of checks that way:

* also it is not relocate strings that do not include escaped characters
* we do not need to differentiate between long and short strings
* we don't need to count string length any more